### PR TITLE
Ftr update to net8

### DIFF
--- a/src/WindowWatchApp.Avalonia.Desktop/WindowWatchApp.Avalonia.Desktop.csproj
+++ b/src/WindowWatchApp.Avalonia.Desktop/WindowWatchApp.Avalonia.Desktop.csproj
@@ -3,7 +3,7 @@
     <OutputType>WinExe</OutputType>
     <!--If you are willing to use Windows/MacOS native APIs you will need to create 3 projects.
     One for Windows with net7.0-windows TFM, one for MacOS with net7.0-macos and one with net7.0 TFM for Linux.-->
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
     <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/src/WindowWatchApp.Avalonia.Desktop/WindowWatchApp.Avalonia.Desktop.csproj
+++ b/src/WindowWatchApp.Avalonia.Desktop/WindowWatchApp.Avalonia.Desktop.csproj
@@ -7,6 +7,7 @@
     <Nullable>enable</Nullable>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
     <ApplicationManifest>app.manifest</ApplicationManifest>
+    <LangVersion>latestmajor</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/WindowWatchApp.Avalonia/WindowWatchApp.Avalonia.csproj
+++ b/src/WindowWatchApp.Avalonia/WindowWatchApp.Avalonia.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>

--- a/src/WindowWatchApp.Avalonia/WindowWatchApp.Avalonia.csproj
+++ b/src/WindowWatchApp.Avalonia/WindowWatchApp.Avalonia.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>latestmajor</LangVersion>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
   </PropertyGroup>
 

--- a/src/WindowWatchApp.Common.Windows/WindowWatchApp.Common.Windows.csproj
+++ b/src/WindowWatchApp.Common.Windows/WindowWatchApp.Common.Windows.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/WindowWatchApp.Common.Windows/WindowWatchApp.Common.Windows.csproj
+++ b/src/WindowWatchApp.Common.Windows/WindowWatchApp.Common.Windows.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <LangVersion>latestmajor</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/WindowWatchApp.Common/WindowWatchApp.Common.csproj
+++ b/src/WindowWatchApp.Common/WindowWatchApp.Common.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/WindowWatchApp.Common/WindowWatchApp.Common.csproj
+++ b/src/WindowWatchApp.Common/WindowWatchApp.Common.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <LangVersion>latestmajor</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/WindowWatchApp.Console/WindowWatchApp.Console.csproj
+++ b/src/WindowWatchApp.Console/WindowWatchApp.Console.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/WindowWatchApp.Console/WindowWatchApp.Console.csproj
+++ b/src/WindowWatchApp.Console/WindowWatchApp.Console.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <LangVersion>latestmajor</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request includes several updates to the project files across multiple components to upgrade the target framework to .NET 8.0 and set the language version to the latest major version. These changes ensure that the projects use the most recent features and improvements available in .NET 8.0.

### Framework and Language Version Upgrades:

* [`src/WindowWatchApp.Avalonia.Desktop/WindowWatchApp.Avalonia.Desktop.csproj`](diffhunk://#diff-91fe4f23ce0d9a6c5859e454fbe415e50b63eff96546fd11c27210793ff1b79eL6-R10): Upgraded the target framework from `net7.0` to `net8.0` and set the language version to `latestmajor`.
* [`src/WindowWatchApp.Avalonia/WindowWatchApp.Avalonia.csproj`](diffhunk://#diff-bf9e841d6d9a89ad440d6c34ce762533761ffba3cfe00063039508d73ab404cdL3-R5): Upgraded the target framework from `net7.0` to `net8.0` and set the language version to `latestmajor`.
* [`src/WindowWatchApp.Common.Windows/WindowWatchApp.Common.Windows.csproj`](diffhunk://#diff-fd7105f36f7289da5efc32fcb9d194d0ac517d50044b8e1f0fee816b60fe1725L4-R7): Upgraded the target framework from `net6.0` to `net8.0` and set the language version to `latestmajor`.
* [`src/WindowWatchApp.Common/WindowWatchApp.Common.csproj`](diffhunk://#diff-157c89ac32a3f965ec2077e6ac926c9a8961929f19dc8cac617519af5eeebb1eL4-R7): Upgraded the target framework from `net6.0` to `net8.0` and set the language version to `latestmajor`.
* [`src/WindowWatchApp.Console/WindowWatchApp.Console.csproj`](diffhunk://#diff-20a51723884d014cba8b3f893199c48dbfa0d2125850823feb925bc430c8f151L5-R8): Upgraded the target framework from `net6.0` to `net8.0` and set the language version to `latestmajor`.